### PR TITLE
fix(php8): Use compatible string access syntax

### DIFF
--- a/hybridauth/Hybrid/thirdparty/OAuth/OAuth.php
+++ b/hybridauth/Hybrid/thirdparty/OAuth/OAuth.php
@@ -103,7 +103,7 @@ abstract class OAuthSignatureMethod {
     // Avoid a timing leak with a (hopefully) time insensitive compare
     $result = 0;
     for ($i = 0; $i < strlen($signature); $i++) {
-      $result |= ord($built{$i}) ^ ord($signature{$i});
+      $result |= ord($built[$i]) ^ ord($signature[$i]);
     }
 
     return $result == 0;


### PR DESCRIPTION
Fixes:

```
Fatal error: Array and string offset access syntax with curly braces is no longer supported in 
/var/www/html/docroot/profiles/spotlight_profile/libraries/hybridauth/hybridauth/Hybrid/thirdparty/OAuth/OAuth.php on line 106
```